### PR TITLE
Fix bug for when assign_params is a list.

### DIFF
--- a/cadCAD_tools/execution/easy_run.py
+++ b/cadCAD_tools/execution/easy_run.py
@@ -85,7 +85,7 @@ def easy_run(
         if assign_params == True:
             pass
         else:
-            params_set &= assign_params
+            params_set &= set(assign_params)
 
         # Logic for getting the assign params criteria
         if type(assign_params) is list:


### PR DESCRIPTION
easy_run was crashing when `assign_params` was a list. This should fix it.